### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions:
+  contents: read
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/sahiixx/system-prompts-and-models-of-ai-tools/security/code-scanning/1](https://github.com/sahiixx/system-prompts-and-models-of-ai-tools/security/code-scanning/1)

The fix involves restricting the permissions of the GITHUB_TOKEN in the workflow. The minimal and recommended approach is to add a top-level `permissions:` block to the workflow YAML after the `name:` (line 3 or 4). Since this workflow does not require write actions (it simply echoes an input variable), it is safest to set all permissions to `none` or, at minimum, set `contents: read` as shown in best practice documentation. Specifically:  
- In `.github/workflows/manual.yml`, immediately after the workflow `name`, insert a `permissions` block:
  ```yaml
  permissions:
    contents: read
  ```
  This ensures the workflow jobs have only read access to the repository contents via GITHUB_TOKEN, providing least privilege. If even this is not needed (job does not touch repo at all), you may use `contents: none`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to explicitly grant read access to repository contents. Triggers, inputs, and steps remain unchanged, and workflows continue to run manually as before.
* **Security**
  * Adopted a least-privilege configuration for CI, reducing unnecessary access scope and improving security posture.
* **No User-Facing Changes**
  * No impact on application features or behavior; this update only affects internal CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->